### PR TITLE
fixed deprecation warning in rails 3.2

### DIFF
--- a/lib/mongoid_spacial/spacial/document.rb
+++ b/lib/mongoid_spacial/spacial/document.rb
@@ -20,11 +20,9 @@ module Mongoid
         end
       end
 
-      module InstanceMethods #:nodoc:
-        def distance_from(key,p2, opts = {})
-          p1 = self.send(key)
-          Mongoid::Spacial.distance(p1, p2, opts)
-        end
+      def distance_from(key,p2, opts = {})
+        p1 = self.send(key)
+        Mongoid::Spacial.distance(p1, p2, opts)
       end
     end
   end


### PR DESCRIPTION
hi ryan,

activesupport::concern wont include the InstanceMethods module automatically. instead one should define the methods directly in the parent module.

i tested it with rails 3.1.3 and 3.2.0.rc2 - works fine

best regards
linki
