### PR TITLE
Fix namespacing issue in #31

### DIFF
--- a/lib/mongoid_spacial/spacial/document.rb
+++ b/lib/mongoid_spacial/spacial/document.rb
@@ -16,7 +16,7 @@ module Mongoid
         # @param [Hash] options options for spacial_index
         def spacial_index name, *options
           self.spacial_fields_indexed << name
-          index [[ name, Mongo::GEO2D ]], *options
+          index [[ name, ::Mongo::GEO2D ]], *options
         end
       end
 


### PR DESCRIPTION
Added in `::Mongo` so we use the top level namespace and dont get the following error.

```
uninitialized constant Mongoid::Spacial::Document::ClassMethods::Mongo
```
